### PR TITLE
Fix response error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,5 +142,8 @@ api.updateUserMetadata = (metadata, function (err, res) {
 ```
 
 ## Changelog
-1.0.0
+#### 1.0.1
+- Fixed response error checking.
+
+#### 1.0.0
 - Migrated to instance based architecture. You have to create new instance using `Initialize` function now. See documentation above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sc2-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sc2-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SteemConnect v2 SDK",
   "main": "lib/sc2.js",
   "scripts": {


### PR DESCRIPTION
Fixes #28 
Fixes #26 

The library should check if there is `error` object in JSON response. As `res.json()` is asynchronous and returns promise we were checking if `error` exists on the promise. As node's implementation of fetch has `error` method present this was causing every request to fail in node environment.